### PR TITLE
Remove hall description

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           <div class="button" id="next-level">další level</div>
           <div class="button" id="sign-to-hall">zapsat se do síně slávy</div>
         </div>
-        <div class="sign2hall hidden" id="sign2hall">
+        <div class="sign2hall" id="sign2hall">
           <h2>Zapsat se do síně slávy</h2>
           <p>
             <strong>Přezdívka</strong> - spolu s ní bude do Síně slávy vytesáno

--- a/index.html
+++ b/index.html
@@ -65,10 +65,6 @@
         <div class="sign2hall hidden" id="sign2hall">
           <h2>Zapsat se do síně slávy</h2>
           <p>
-            Pokud se rozhodneš vytesat své jméno do síně slávy, máš šanci na
-            diecézku vyhrát speciální dárek.
-          </p>
-          <p>
             <strong>Přezdívka</strong> - spolu s ní bude do Síně slávy vytesáno
             maximální skóre.
           </p>

--- a/style.css
+++ b/style.css
@@ -348,6 +348,10 @@ a {
   border-radius: 0.3rem;
   color: #faf8ef;
   padding: 1rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .sign2hall .button {
   color: #776e65;
@@ -362,7 +366,7 @@ a {
 
 .sign2hall .input {
   background: #fafafa;
-  width: 90%;
+  width: 80%;
   margin-top: 1rem;
   border: none;
   border-radius: 0.3rem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed extraneous promotional text from the hall of fame registration section to streamline the displayed instructions, now focusing solely on the required nickname and secret word for sign-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->